### PR TITLE
Fix python_requires

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ packages = find:
 package_dir =
     =src
 include_package_data = True
-python_requires = ~= 3.6
+python_requires = >= 3.6
 install_requires =
 
 [options.packages.find]


### PR DESCRIPTION
Current value means python >=3.6,<3.7